### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Then configure the rules you want to use under the rules section.
 ```json
 {
     "rules": {
-        "only-ascii/rule-name": 2
+        "only-ascii/only-ascii": 2
     }
 }
 ```


### PR DESCRIPTION
only-ascii/rule-name => only-ascii/only-ascii